### PR TITLE
LC-114- bug fixed - footer stays at the bottom of page

### DIFF
--- a/client/src/components/Navbar/index.tsx
+++ b/client/src/components/Navbar/index.tsx
@@ -42,8 +42,10 @@ const NavBar: React.FC = () => {
         </div>
       </div>
     </div>
-<Outlet/>
-<Footer/>
+    <div className="flex flex-col min-h-screen justify-between ">
+    <Outlet/>
+    <Footer/>
+  </div>  
       </>
     )};
 


### PR DESCRIPTION
The bug regarding the footer not staying at the bottom of the page has been fixed in this pull request. We have made necessary changes and tested thoroughly to ensure that the footer is now properly aligned and stays at the bottom of the page in all scenarios. Please review and let us know if you have any further concerns.