### PR TITLE
LC-114-Bug-Footer-is-not-staying-at-the-bottom-of-the-page1

### DIFF
--- a/client/src/Routes/ScreenContent/index.tsx
+++ b/client/src/Routes/ScreenContent/index.tsx
@@ -5,10 +5,11 @@ const ScreenContent = () => {
   return (
     <>
       <Navbar />
-      <div className="flex flex-col min-h-screen justify-between">
+      <div className="min-h-screen" style={{ backgroundColor: "#F7F9FB" }}>
         <Outlet/>
-        <Footer/>
       </div>
+      
+      <Footer/>
     </>
   );
 };


### PR DESCRIPTION
Fixed footer design since it was extending the footer when the content of the body was empty